### PR TITLE
chore: add repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Repository ownership for GitHub reviews and Aikido issue routing.
+# Keep this file in sync with the person responsible for this repository.
+* @fpl-switstack


### PR DESCRIPTION
Summary
Add CODEOWNERS so Aikido can map repository findings to the responsible team.